### PR TITLE
Finish migration for pyo3 0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ libc = "0.2"
 num-complex = "0.2"
 num-traits = "0.2"
 ndarray = ">=0.13"
-pyo3 = { git = "https://github.com/PyO3/pyo3" }
+pyo3 = "0.12.0"
 
 [features]
 # In default setting, python version is automatically detected

--- a/examples/linalg/Cargo.toml
+++ b/examples/linalg/Cargo.toml
@@ -14,5 +14,5 @@ ndarray = ">= 0.13"
 ndarray-linalg = { version = "0.12", features = ["openblas"] }
 
 [dependencies.pyo3]
-version = "0.11.1"
+version = "0.12.0"
 features = ["extension-module"]

--- a/examples/simple-extension/Cargo.toml
+++ b/examples/simple-extension/Cargo.toml
@@ -13,5 +13,5 @@ numpy = { path = "../.." }
 ndarray = ">= 0.12"
 
 [dependencies.pyo3]
-version = "0.11.1"
+version = "0.12.0"
 features = ["extension-module"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 //! Defines error types.
 use crate::types::DataType;
-use pyo3::{exceptions as exc, PyErr, PyErrArguments, PyErrValue, PyObject, Python, ToPyObject};
+use pyo3::{exceptions as exc, PyErr, PyErrArguments, PyObject, Python, ToPyObject};
 use std::fmt;
 
 /// Represents a dimension and dtype of numpy array.
@@ -63,14 +63,14 @@ macro_rules! impl_pyerr {
         impl std::error::Error for $err_type {}
 
         impl PyErrArguments for $err_type {
-            fn arguments(&self, py: Python) -> PyObject {
+            fn arguments(self, py: Python) -> PyObject {
                 format!("{}", self).to_object(py)
             }
         }
 
         impl std::convert::From<$err_type> for PyErr {
             fn from(err: $err_type) -> PyErr {
-                PyErr::from_value::<exc::PyTypeError>(PyErrValue::from_err_args(err))
+                exc::PyTypeError::new_err(err)
             }
         }
     };

--- a/src/npyffi/array.rs
+++ b/src/npyffi/array.rs
@@ -45,7 +45,7 @@ impl PyArrayAPI {
             Python::with_gil(|py| {
                 let api = get_numpy_api(py, MOD_NAME, CAPSULE_NAME);
                 self.api.set(api);
-            })
+            });
         }
         unsafe { self.api.get().offset(offset) }
     }

--- a/src/npyffi/array.rs
+++ b/src/npyffi/array.rs
@@ -42,9 +42,10 @@ impl PyArrayAPI {
     }
     fn get(&self, offset: isize) -> *const *const c_void {
         if self.api.get().is_null() {
-            let ensure_gil = pyo3::internal_utils::ensure_gil();
-            let api = get_numpy_api(unsafe { ensure_gil.python() }, MOD_NAME, CAPSULE_NAME);
-            self.api.set(api);
+            Python::with_gil(|py| {
+                let api = get_numpy_api(py, MOD_NAME, CAPSULE_NAME);
+                self.api.set(api);
+            })
         }
         unsafe { self.api.get().offset(offset) }
     }

--- a/src/npyffi/ufunc.rs
+++ b/src/npyffi/ufunc.rs
@@ -4,6 +4,7 @@ use std::os::raw::*;
 use std::{cell::Cell, ptr};
 
 use pyo3::ffi::PyObject;
+use pyo3::Python;
 
 use super::get_numpy_api;
 use super::objects::*;
@@ -28,9 +29,10 @@ impl PyUFuncAPI {
     }
     fn get(&self, offset: isize) -> *const *const c_void {
         if self.api.get().is_null() {
-            let ensure_gil = pyo3::internal_utils::ensure_gil();
-            let api = get_numpy_api(unsafe { ensure_gil.python() }, MOD_NAME, CAPSULE_NAME);
-            self.api.set(api);
+            Python::with_gil(|py| {
+                let api = get_numpy_api(py, MOD_NAME, CAPSULE_NAME);
+                self.api.set(api);
+            })
         }
         unsafe { self.api.get().offset(offset) }
     }

--- a/src/npyffi/ufunc.rs
+++ b/src/npyffi/ufunc.rs
@@ -32,7 +32,7 @@ impl PyUFuncAPI {
             Python::with_gil(|py| {
                 let api = get_numpy_api(py, MOD_NAME, CAPSULE_NAME);
                 self.api.set(api);
-            })
+            });
         }
         unsafe { self.api.get().offset(offset) }
     }


### PR DESCRIPTION
Now that pyo3 0.12.0 is released the need for this has increased. I took care of updating the last pieces blocking this branch and updated the `Cargo.toml` to use 0.12.0 instead of the git link.